### PR TITLE
fix: lowercase spacelift cert thumbprint for better importing

### DIFF
--- a/spacelift.tf
+++ b/spacelift.tf
@@ -1,7 +1,7 @@
 # Spacelift OIDC connection
 
 locals {
-  spacelift_thumbprint = replace(var.spacelift_thumbprint, ":", "")
+  spacelift_thumbprint = lower(replace(var.spacelift_thumbprint, ":", ""))
 }
 
 resource "aws_iam_openid_connect_provider" "joberly_app_spacelift_io" {


### PR DESCRIPTION
The thumbprint gets stored by AWS and imported in lowercase. This changes the thumbprint to lowercase in the code so that an import does not cause state drift.